### PR TITLE
    Make the FrameBufferObject class store initial FrameBuffer ID

### DIFF
--- a/Source/Core/OpenGL/FrameBufferObject.cpp
+++ b/Source/Core/OpenGL/FrameBufferObject.cpp
@@ -10,6 +10,7 @@
 #include <kvs/OpenGL>
 #include <kvs/Message>
 
+GLuint kvs::FrameBufferObject::m_unbind_id = 0; // Initialize static unbind id
 
 namespace kvs
 {
@@ -22,6 +23,7 @@ namespace kvs
 void FrameBufferObject::bind() const
 {
     KVS_ASSERT( this->isCreated() );
+    KVS_GL_CALL( glGetIntegerv( GL_FRAMEBUFFER_BINDING, (GLint*)&m_unbind_id ) );
     KVS_GL_CALL( glBindFramebuffer( GL_FRAMEBUFFER, m_id ) );
 }
 
@@ -33,7 +35,7 @@ void FrameBufferObject::bind() const
 void FrameBufferObject::unbind() const
 {
     KVS_ASSERT( this->isBound() );
-    KVS_GL_CALL( glBindFramebuffer( GL_FRAMEBUFFER, 0 ) );
+    KVS_GL_CALL( glBindFramebuffer( GL_FRAMEBUFFER, m_unbind_id ) );
 }
 
 bool FrameBufferObject::isCreated() const
@@ -245,7 +247,7 @@ FrameBufferObject::Binder::Binder( const FrameBufferObject& fbo ) :
 FrameBufferObject::Binder::~Binder()
 {
     KVS_ASSERT( m_fbo.isCreated() );
-    KVS_GL_CALL( glBindFramebuffer( GL_FRAMEBUFFER, 0 ) );
+    m_fbo.unbind();
 }
 
 FrameBufferObject::GuardedBinder::GuardedBinder( const kvs::FrameBufferObject& fbo ):

--- a/Source/Core/OpenGL/FrameBufferObject.h
+++ b/Source/Core/OpenGL/FrameBufferObject.h
@@ -29,6 +29,7 @@ private:
 public:
     class Binder;
     class GuardedBinder;
+    static GLuint m_unbind_id; ///< Initial frame buffer id.
 
 public:
     FrameBufferObject(): m_id( 0 ) {}


### PR DESCRIPTION
    To allow buffered rendering on screen bases that might have a default framebuffer index different from 0
    (such as QOpenGLWidget) we store the initial frame-buffer id in the bind method, so that it can
    be restored by the unbind method.

    The m_unbind_id needs to be static here as the bind method is const. This means all FrameBufffer instances
    will share the m_unbind_id at any given point in time.

    If it is required to render on multiple Screen instances with differing default framebuffer id, m_unbind_id
    might need to be converted to a non-static member.