### PR TITLE
Adding byte alignment ability to VertexBufferObjectManager

### DIFF
--- a/Source/Core/Visualization/Renderer/VertexBufferObjectManager.cpp
+++ b/Source/Core/Visualization/Renderer/VertexBufferObjectManager.cpp
@@ -33,6 +33,8 @@ inline GLenum GLType( const kvs::AnyValueArray& array )
 namespace kvs
 {
 
+GLsizei VertexBufferObjectManager::m_buffer_alignment=1;
+
 VertexBufferObjectManager::VertexBufferObjectManager():
     m_vbo_size( 0 ),
     m_ibo_size( 0 )
@@ -128,39 +130,39 @@ void VertexBufferObjectManager::create()
             m_vbo.bind();
             if ( m_vertex_array.size > 0 )
             {
-                m_vbo.load( m_vertex_array.size, m_vertex_array.pointer, offset );
+                m_vbo.load( getPaddedBufferSize(m_vertex_array), m_vertex_array.pointer, offset );
                 m_vertex_array.offset = offset;
-                offset += m_vertex_array.size;
+                offset += getPaddedBufferSize(m_vertex_array);
             }
 
             if ( m_color_array.size > 0 )
             {
-                m_vbo.load( m_color_array.size, m_color_array.pointer, offset );
+                m_vbo.load( getPaddedBufferSize(m_color_array), m_color_array.pointer, offset );
                 m_color_array.offset = offset;
-                offset += m_color_array.size;
+                offset += getPaddedBufferSize(m_color_array);
             }
 
             if ( m_normal_array.size > 0 )
             {
-                m_vbo.load( m_normal_array.size, m_normal_array.pointer, offset );
+                m_vbo.load( getPaddedBufferSize(m_normal_array), m_normal_array.pointer, offset );
                 m_normal_array.offset = offset;
-                offset += m_normal_array.size;
+                offset += getPaddedBufferSize(m_normal_array);
             }
 
             if ( m_tex_coord_array.size > 0 )
             {
-                m_vbo.load( m_tex_coord_array.size, m_tex_coord_array.pointer, offset );
+                m_vbo.load( getPaddedBufferSize(m_tex_coord_array), m_tex_coord_array.pointer, offset );
                 m_tex_coord_array.offset = offset;
-                offset += m_tex_coord_array.size;
+                offset += getPaddedBufferSize(m_tex_coord_array);
             }
 
             for ( size_t i = 0; i < m_vertex_attrib_arrays.size(); i++ )
             {
                 if ( m_vertex_attrib_arrays[i].size > 0 )
                 {
-                    m_vbo.load( m_vertex_attrib_arrays[i].size, m_vertex_attrib_arrays[i].pointer, offset );
+                    m_vbo.load( getPaddedBufferSize(m_vertex_attrib_arrays[i]), m_vertex_attrib_arrays[i].pointer, offset );
                     m_vertex_attrib_arrays[i].offset = offset;
-                    offset += m_vertex_attrib_arrays[i].size;
+                    offset += getPaddedBufferSize(m_vertex_attrib_arrays[i]);
                 }
             }
 
@@ -241,13 +243,13 @@ void VertexBufferObjectManager::drawElements( GLenum mode, const kvs::ValueArray
 size_t VertexBufferObjectManager::vertex_buffer_object_size() const
 {
     size_t vbo_size = 0;
-    vbo_size += m_vertex_array.size;
-    vbo_size += m_color_array.size;
-    vbo_size += m_normal_array.size;
-    vbo_size += m_tex_coord_array.size;
+    vbo_size += getPaddedBufferSize(m_vertex_array);
+    vbo_size += getPaddedBufferSize(m_color_array );
+    vbo_size += getPaddedBufferSize(m_normal_array);
+    vbo_size += getPaddedBufferSize(m_tex_coord_array);
     for ( size_t i = 0; i < m_vertex_attrib_arrays.size(); i++ )
     {
-        vbo_size += m_vertex_attrib_arrays[i].size;
+        vbo_size += getPaddedBufferSize(m_vertex_attrib_arrays[i]);
     }
     return vbo_size;
 }

--- a/Source/Core/Visualization/Renderer/VertexBufferObjectManager.cpp
+++ b/Source/Core/Visualization/Renderer/VertexBufferObjectManager.cpp
@@ -1,9 +1,3 @@
-/*****************************************************************************/
-/**
- *  @file   VertexBufferObjectManager.cpp
- *  @author Naohisa Sakamoto
- */
-/*****************************************************************************/
 #include "VertexBufferObjectManager.h"
 #include <algorithm>
 
@@ -32,6 +26,8 @@ inline GLenum GLType( const kvs::AnyValueArray& array )
 
 namespace kvs
 {
+
+GLsizei VertexBufferObjectManager::m_buffer_alignment=1;
 
 VertexBufferObjectManager::VertexBufferObjectManager():
     m_vbo_size( 0 ),
@@ -128,39 +124,39 @@ void VertexBufferObjectManager::create()
             m_vbo.bind();
             if ( m_vertex_array.size > 0 )
             {
-                m_vbo.load( m_vertex_array.size, m_vertex_array.pointer, offset );
+                m_vbo.load( getPaddedBufferSize(m_vertex_array), m_vertex_array.pointer, offset );
                 m_vertex_array.offset = offset;
-                offset += m_vertex_array.size;
+                offset += getPaddedBufferSize(m_vertex_array);
             }
 
             if ( m_color_array.size > 0 )
             {
-                m_vbo.load( m_color_array.size, m_color_array.pointer, offset );
+                m_vbo.load( getPaddedBufferSize(m_color_array), m_color_array.pointer, offset );
                 m_color_array.offset = offset;
-                offset += m_color_array.size;
+                offset += getPaddedBufferSize(m_color_array);
             }
 
             if ( m_normal_array.size > 0 )
             {
-                m_vbo.load( m_normal_array.size, m_normal_array.pointer, offset );
+                m_vbo.load( getPaddedBufferSize(m_normal_array), m_normal_array.pointer, offset );
                 m_normal_array.offset = offset;
-                offset += m_normal_array.size;
+                offset += getPaddedBufferSize(m_normal_array);
             }
 
             if ( m_tex_coord_array.size > 0 )
             {
-                m_vbo.load( m_tex_coord_array.size, m_tex_coord_array.pointer, offset );
+                m_vbo.load( getPaddedBufferSize(m_tex_coord_array), m_tex_coord_array.pointer, offset );
                 m_tex_coord_array.offset = offset;
-                offset += m_tex_coord_array.size;
+                offset += getPaddedBufferSize(m_tex_coord_array);
             }
 
             for ( size_t i = 0; i < m_vertex_attrib_arrays.size(); i++ )
             {
                 if ( m_vertex_attrib_arrays[i].size > 0 )
                 {
-                    m_vbo.load( m_vertex_attrib_arrays[i].size, m_vertex_attrib_arrays[i].pointer, offset );
+                    m_vbo.load( getPaddedBufferSize(m_vertex_attrib_arrays[i]), m_vertex_attrib_arrays[i].pointer, offset );
                     m_vertex_attrib_arrays[i].offset = offset;
-                    offset += m_vertex_attrib_arrays[i].size;
+                    offset += getPaddedBufferSize(m_vertex_attrib_arrays[i]);
                 }
             }
 
@@ -241,13 +237,13 @@ void VertexBufferObjectManager::drawElements( GLenum mode, const kvs::ValueArray
 size_t VertexBufferObjectManager::vertex_buffer_object_size() const
 {
     size_t vbo_size = 0;
-    vbo_size += m_vertex_array.size;
-    vbo_size += m_color_array.size;
-    vbo_size += m_normal_array.size;
-    vbo_size += m_tex_coord_array.size;
+    vbo_size += getPaddedBufferSize(m_vertex_array);
+    vbo_size += getPaddedBufferSize(m_color_array );
+    vbo_size += getPaddedBufferSize(m_normal_array);
+    vbo_size += getPaddedBufferSize(m_tex_coord_array);
     for ( size_t i = 0; i < m_vertex_attrib_arrays.size(); i++ )
     {
-        vbo_size += m_vertex_attrib_arrays[i].size;
+        vbo_size += getPaddedBufferSize(m_vertex_attrib_arrays[i]);
     }
     return vbo_size;
 }

--- a/Source/Core/Visualization/Renderer/VertexBufferObjectManager.h
+++ b/Source/Core/Visualization/Renderer/VertexBufferObjectManager.h
@@ -65,11 +65,13 @@ public:
 public:
     class Binder;
 
+    static GLsizei m_buffer_alignment; //Default initalized to 1
 private:
     kvs::VertexBufferObject m_vbo;
     kvs::IndexBufferObject m_ibo;
     size_t m_vbo_size;
     size_t m_ibo_size;
+
 
     VertexBuffer m_vertex_array;
     VertexBuffer m_color_array;
@@ -97,6 +99,10 @@ public:
     void setIndexArray( const kvs::AnyValueArray& array );
     void setVertexAttribArray( const kvs::AnyValueArray& array, const size_t index, const size_t dim, const bool normalized = false, const size_t stride = 0 );
 
+
+    GLsizei getPaddedBufferSize(VertexBuffer buff) const{
+        return ceil(buff.size / (double)m_buffer_alignment ) * m_buffer_alignment;
+    }
     void create();
     void bind() const;
     void unbind() const;

--- a/Source/Core/Visualization/Renderer/VertexBufferObjectManager.h
+++ b/Source/Core/Visualization/Renderer/VertexBufferObjectManager.h
@@ -1,9 +1,3 @@
-/*****************************************************************************/
-/**
- *  @file   VertexBufferObjectManager.h
- *  @author Naohisa Sakamoto
- */
-/*****************************************************************************/
 #pragma once
 #include <kvs/VertexBufferObject>
 #include <kvs/IndexBufferObject>
@@ -65,11 +59,13 @@ public:
 public:
     class Binder;
 
+    static GLsizei m_buffer_alignment; //Default initalized to 1
 private:
     kvs::VertexBufferObject m_vbo;
     kvs::IndexBufferObject m_ibo;
     size_t m_vbo_size;
     size_t m_ibo_size;
+
 
     VertexBuffer m_vertex_array;
     VertexBuffer m_color_array;
@@ -97,6 +93,10 @@ public:
     void setIndexArray( const kvs::AnyValueArray& array );
     void setVertexAttribArray( const kvs::AnyValueArray& array, const size_t index, const size_t dim, const bool normalized = false, const size_t stride = 0 );
 
+
+    GLsizei getPaddedBufferSize(VertexBuffer buff) const{
+        return ceil(buff.size / (double)m_buffer_alignment ) * m_buffer_alignment;
+    }
     void create();
     void bind() const;
     void unbind() const;


### PR DESCRIPTION
Adding the ability to align buffers on byte boundaries in  VertexBufferObjectManager . 
Some hardware (particularly older) is sensitive to byte alignment of buffers. This allows the optional setting of a byte alignment parameter in the VertexBufferObjectManager.   (More extensive explanation in separate email )

