### PR TITLE
VertexBuffer getPaddedSize moved inside BufferObject

### DIFF
--- a/Source/Core/OpenGL/BufferObject.cpp
+++ b/Source/Core/OpenGL/BufferObject.cpp
@@ -158,13 +158,25 @@ bool BufferObject::isBound() const
 
 /*===========================================================================*/
 /**
+ *  Returns the padded buffer size  for input size.
+ *  @return buffer size
+ */
+/*===========================================================================*/
+GLsizei BufferObject::paddedBufferSize(GLsizei size)
+{
+     int x = size;
+     return (x + 15) & ~15;
+}
+
+/*===========================================================================*/
+/**
  *  Load buffer data from CPU to GPU.
  *  @param  size [in] buffer data size
  *  @param  data [in] pointer to loaded buffer data
  *  @param  offset [in] texel offset within the existing buffer data array
  */
 /*===========================================================================*/
-void BufferObject::load( const size_t size, const void* data, const size_t offset )
+GLsizei BufferObject::load( const size_t size, const void* data, const size_t offset )
 {
     if ( !m_is_loaded )
     {
@@ -175,6 +187,7 @@ void BufferObject::load( const size_t size, const void* data, const size_t offse
     {
         this->setBufferSubData( size, data, offset );
     }
+    return paddedBufferSize(size);
 }
 
 /*===========================================================================*/

--- a/Source/Core/OpenGL/BufferObject.h
+++ b/Source/Core/OpenGL/BufferObject.h
@@ -66,6 +66,8 @@ public:
     GLuint id() const;
     GLenum target() const;
     GLenum targetBinding() const;
+    static GLsizei paddedBufferSize( GLsizei size);
+
     size_t size() const;
 
     void setUsage( const GLenum usage );
@@ -79,7 +81,7 @@ public:
     bool isValid() const;
     bool isBound() const;
 
-    void load( const size_t size, const void* data, const size_t offset = 0 );
+    GLsizei load( const size_t size, const void* data, const size_t offset = 0 );
     void* map( const GLenum access_type = kvs::BufferObject::ReadWrite );
     void unmap();
 

--- a/Source/Core/Visualization/Renderer/VertexBufferObjectManager.cpp
+++ b/Source/Core/Visualization/Renderer/VertexBufferObjectManager.cpp
@@ -33,8 +33,6 @@ inline GLenum GLType( const kvs::AnyValueArray& array )
 namespace kvs
 {
 
-GLsizei VertexBufferObjectManager::m_buffer_alignment=1;
-
 VertexBufferObjectManager::VertexBufferObjectManager():
     m_vbo_size( 0 ),
     m_ibo_size( 0 )
@@ -130,39 +128,34 @@ void VertexBufferObjectManager::create()
             m_vbo.bind();
             if ( m_vertex_array.size > 0 )
             {
-                m_vbo.load( getPaddedBufferSize(m_vertex_array), m_vertex_array.pointer, offset );
                 m_vertex_array.offset = offset;
-                offset += getPaddedBufferSize(m_vertex_array);
+                offset += m_vbo.load(m_vertex_array.size, m_vertex_array.pointer, m_vertex_array.offset  );
             }
 
             if ( m_color_array.size > 0 )
             {
-                m_vbo.load( getPaddedBufferSize(m_color_array), m_color_array.pointer, offset );
                 m_color_array.offset = offset;
-                offset += getPaddedBufferSize(m_color_array);
+                offset += m_vbo.load( m_color_array.size, m_color_array.pointer,  m_color_array.offset );
             }
 
             if ( m_normal_array.size > 0 )
             {
-                m_vbo.load( getPaddedBufferSize(m_normal_array), m_normal_array.pointer, offset );
                 m_normal_array.offset = offset;
-                offset += getPaddedBufferSize(m_normal_array);
+                offset += m_vbo.load( m_normal_array.size, m_normal_array.pointer, m_normal_array.offset );
             }
 
             if ( m_tex_coord_array.size > 0 )
             {
-                m_vbo.load( getPaddedBufferSize(m_tex_coord_array), m_tex_coord_array.pointer, offset );
                 m_tex_coord_array.offset = offset;
-                offset += getPaddedBufferSize(m_tex_coord_array);
+                offset +=  m_vbo.load( m_tex_coord_array.size, m_tex_coord_array.pointer, m_tex_coord_array.offset );
             }
 
             for ( size_t i = 0; i < m_vertex_attrib_arrays.size(); i++ )
             {
                 if ( m_vertex_attrib_arrays[i].size > 0 )
                 {
-                    m_vbo.load( getPaddedBufferSize(m_vertex_attrib_arrays[i]), m_vertex_attrib_arrays[i].pointer, offset );
                     m_vertex_attrib_arrays[i].offset = offset;
-                    offset += getPaddedBufferSize(m_vertex_attrib_arrays[i]);
+                    offset +=  m_vbo.load( m_vertex_attrib_arrays[i].size, m_vertex_attrib_arrays[i].pointer, m_vertex_attrib_arrays[i].offset );
                 }
             }
 
@@ -243,13 +236,13 @@ void VertexBufferObjectManager::drawElements( GLenum mode, const kvs::ValueArray
 size_t VertexBufferObjectManager::vertex_buffer_object_size() const
 {
     size_t vbo_size = 0;
-    vbo_size += getPaddedBufferSize(m_vertex_array);
-    vbo_size += getPaddedBufferSize(m_color_array );
-    vbo_size += getPaddedBufferSize(m_normal_array);
-    vbo_size += getPaddedBufferSize(m_tex_coord_array);
+    vbo_size += BufferObject::paddedBufferSize(m_vertex_array.size);
+    vbo_size += BufferObject::paddedBufferSize(m_color_array.size);
+    vbo_size += BufferObject::paddedBufferSize(m_normal_array.size);
+    vbo_size += BufferObject::paddedBufferSize(m_tex_coord_array.size);
     for ( size_t i = 0; i < m_vertex_attrib_arrays.size(); i++ )
     {
-        vbo_size += getPaddedBufferSize(m_vertex_attrib_arrays[i]);
+        vbo_size += BufferObject::paddedBufferSize(m_vertex_attrib_arrays[i].size);
     }
     return vbo_size;
 }

--- a/Source/Core/Visualization/Renderer/VertexBufferObjectManager.h
+++ b/Source/Core/Visualization/Renderer/VertexBufferObjectManager.h
@@ -65,7 +65,6 @@ public:
 public:
     class Binder;
 
-    static GLsizei m_buffer_alignment; //Default initalized to 1
 private:
     kvs::VertexBufferObject m_vbo;
     kvs::IndexBufferObject m_ibo;
@@ -99,10 +98,6 @@ public:
     void setIndexArray( const kvs::AnyValueArray& array );
     void setVertexAttribArray( const kvs::AnyValueArray& array, const size_t index, const size_t dim, const bool normalized = false, const size_t stride = 0 );
 
-
-    GLsizei getPaddedBufferSize(VertexBuffer buff) const{
-        return ceil(buff.size / (double)m_buffer_alignment ) * m_buffer_alignment;
-    }
     void create();
     void bind() const;
     void unbind() const;


### PR DESCRIPTION
Implementation of  paddedBufferSize inside BufferObject.

Resending a cleaned up version that should merge neatly into your develop branch.